### PR TITLE
Add 'path' property to Swift 4 manifest.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -20,9 +20,13 @@ let package = Package(
         // Targets can depend on other targets in this package, and on products in packages which this package depends on.
         .target(
             name: "<#Format#>",
-            dependencies: []),
+            dependencies: [],
+            path: "Sources"
+        ),
         .testTarget(
             name: "<#Format#>Tests",
-            dependencies: ["<#Format#>"]),
+            dependencies: ["<#Format#>"],
+            path: "Tests"
+        ),
     ]
 )


### PR DESCRIPTION
To avoid an error when `swift package generate-xcodeproj` like below:
`error: could not find source files for target(s): <Format>; use the 'path' property in the Swift 4 manifest to set a custom target path`

A small change that gets past an error I encountered with the latest tooling.